### PR TITLE
Add a JSON validator for configuration files.

### DIFF
--- a/AMPT.iml
+++ b/AMPT.iml
@@ -58,7 +58,6 @@
     <orderEntry type="library" scope="PROVIDED" name="Maven: com.jcraft:jsch:0.1.55" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: net.imagej:imagej-plugins-uploader-webdav:0.3.2" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.jackrabbit:jackrabbit-webdav:2.21.1" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.slf4j:slf4j-api:1.7.30" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.httpcomponents:httpclient:4.5.12" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: commons-codec:commons-codec:1.14" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: org.apache.httpcomponents:httpcore:4.4.13" level="project" />
@@ -216,6 +215,12 @@
     <orderEntry type="library" scope="PROVIDED" name="Maven: commons-beanutils:commons-beanutils:1.9.4" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: commons-logging:commons-logging:1.2" level="project" />
     <orderEntry type="library" scope="PROVIDED" name="Maven: commons-collections:commons-collections:3.2.2" level="project" />
-    <orderEntry type="library" name="Maven: com.cedarsoftware:json-io:4.12.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.cedarsoftware:json-io:4.12.0" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.fasterxml.jackson.core:jackson-core:2.9.6" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.fasterxml.jackson.core:jackson-annotations:2.9.6" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.fasterxml.jackson.core:jackson-databind:2.9.6" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.slf4j:slf4j-api:1.7.31" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.slf4j:slf4j-simple:1.7.31" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.networknt:json-schema-validator:1.0.55" level="project" />
   </component>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -158,5 +158,38 @@
             <artifactId>json-io</artifactId>
             <version>4.12.0</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.9.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.9.6</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.9.6</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.31</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.31</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>json-schema-validator</artifactId>
+            <version>1.0.55</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/vulcan/vmlci/orca/AMPT_Main.java
+++ b/src/main/java/com/vulcan/vmlci/orca/AMPT_Main.java
@@ -41,7 +41,8 @@ public class AMPT_Main implements Command {
     logger.info("Starting AMPT");
     SwingUtilities.invokeLater(
         () -> {
-          if (!ConfigurationManager.checkFormatVersions()) {
+          if (!ConfigurationManager.validateConfigs()
+              || !ConfigurationManager.checkFormatVersions()) {
             return;
           }
           if (null == AMPT_Main.controlWindow) {

--- a/src/main/java/com/vulcan/vmlci/orca/helpers/ConfigurationFile.java
+++ b/src/main/java/com/vulcan/vmlci/orca/helpers/ConfigurationFile.java
@@ -18,12 +18,15 @@ package com.vulcan.vmlci.orca.helpers;
 
 /** Existing configuration files and their properties. */
 public enum ConfigurationFile {
-  CUE_CONFIG("CueConfig.json", 1),
-  MEASUREMENT_CONFIG("MeasurementConf.json", 0),
-  REFERENCE_CONFIG("ReferenceConf.json", 0);
+  CUE_CONFIG("CueConfig.json", "CueConfig.schema.json", 1),
+  MEASUREMENT_CONFIG("MeasurementConf.json", "MeasurementConf.schema.json", 0),
+  REFERENCE_CONFIG("ReferenceConf.json", "ReferenceConf.schema.json", 0);
 
   /** The base name of the configuration file. */
   private final String filename;
+
+  /** The schema file name for the configuration file. */
+  private final String schemaFilename;
 
   /**
    * The current format version of the configuration file.
@@ -34,13 +37,18 @@ public enum ConfigurationFile {
    */
   private final int formatVersion;
 
-  ConfigurationFile(String filename, int formatVersion) {
+  ConfigurationFile(String filename, String schemaFilename, int formatVersion) {
     this.filename = filename;
+    this.schemaFilename = schemaFilename;
     this.formatVersion = formatVersion;
   }
 
   public String getFilename() {
     return filename;
+  }
+
+  public String getSchemaFilename() {
+    return schemaFilename;
   }
 
   public int getFormatVersion() {

--- a/src/main/java/com/vulcan/vmlci/orca/helpers/ConfigurationManager.java
+++ b/src/main/java/com/vulcan/vmlci/orca/helpers/ConfigurationManager.java
@@ -16,6 +16,8 @@
 
 package com.vulcan.vmlci.orca.helpers;
 
+import com.vulcan.vmlci.orca.validator.JsonConfigValidator;
+import com.vulcan.vmlci.orca.validator.JsonValidationException;
 import org.apache.commons.io.FilenameUtils;
 import org.scijava.log.Logger;
 import org.scijava.log.StderrLogService;
@@ -34,6 +36,8 @@ import java.util.Set;
 /** Helpers for managing configuration files. */
 @SuppressWarnings({"FinalClass", "UtilityClass", "UtilityClassCanBeEnum"})
 public final class ConfigurationManager {
+  private static final Logger logger = new StderrLogService();
+
   private static final String FORMAT_VERSION_NAME = "format_version";
 
   private static final String DIALOG_MESSAGE =
@@ -43,6 +47,22 @@ public final class ConfigurationManager {
           + "Would you like to proceed?";
 
   private ConfigurationManager() {}
+
+  /**
+   * Validates the configuration files in the user's preferences directory.
+   *
+   * @return True if all configs are valid, false otherwise.
+   */
+  public static boolean validateConfigs() {
+    try {
+      JsonConfigValidator jsonConfigValidator = new JsonConfigValidator();
+      jsonConfigValidator.validateAllConfigs();
+      return true;
+    } catch (JsonValidationException e) {
+      logger.error(e);
+      return false;
+    }
+  }
 
   /**
    * Checks if the format versions of all existing configuration files are up to date.
@@ -55,8 +75,6 @@ public final class ConfigurationManager {
    *     replace the previous outdated configuration files.
    */
   public static boolean checkFormatVersions() {
-    final Logger logger = new StderrLogService();
-
     final Set<ConfigurationFile> outdatedConfigs;
     try {
       outdatedConfigs = getOutdatedConfigFiles();

--- a/src/main/java/com/vulcan/vmlci/orca/validator/JsonConfigValidator.java
+++ b/src/main/java/com/vulcan/vmlci/orca/validator/JsonConfigValidator.java
@@ -1,0 +1,126 @@
+/*
+ *  Copyright (c) 2021 Vulcan Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.vulcan.vmlci.orca.validator;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonMetaSchema;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.SpecVersion;
+import com.networknt.schema.ValidationMessage;
+import com.vulcan.vmlci.orca.helpers.ConfigurationFile;
+import com.vulcan.vmlci.orca.helpers.ConfigurationLoader;
+import org.scijava.log.Logger;
+import org.scijava.log.StderrLogService;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/** A validator for JSON configuration files. */
+public class JsonConfigValidator {
+  private final JsonSchemaFactory jsonSchemaFactory;
+  private final ObjectMapper mapper = new ObjectMapper();
+  private final Logger logger = new StderrLogService();
+
+  public JsonConfigValidator() throws JsonValidationException {
+    final JsonMetaSchema metaSchema = JsonMetaSchema.getV201909();
+    final JsonSchemaFactory.Builder builder =
+        JsonSchemaFactory.builder(JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V201909))
+            .defaultMetaSchemaURI(metaSchema.getUri())
+            .addMetaSchema(metaSchema)
+            .addUriMappings(getUriMappings());
+    jsonSchemaFactory = builder.build();
+  }
+
+  /**
+   * Validates all configuration files in the user's preference directory.
+   *
+   * @throws JsonValidationException If any validation errors occur.
+   */
+  public void validateAllConfigs() throws JsonValidationException {
+    for (final ConfigurationFile configFile : ConfigurationFile.values()) {
+      final Path configPath =
+          ConfigurationLoader.getAbsoluteConfigurationPath(configFile.getFilename());
+      validateConfig(configPath, configFile.getSchemaFilename());
+    }
+  }
+
+  /**
+   * Validates a given configuration file against a given schema.
+   *
+   * @param configPath The configuration file to validate.
+   * @param schemaFileName The schema file name (last part of the path) to use.
+   * @throws JsonValidationException If any validation errors occur.
+   */
+  public void validateConfig(Path configPath, String schemaFileName)
+      throws JsonValidationException {
+    logger.info("Validating config: " + configPath);
+
+    final JsonSchema schema;
+    try (InputStream schemaInputStream =
+        JsonConfigValidator.class.getResourceAsStream(
+            String.format("/schema/%s", schemaFileName))) {
+      schema = jsonSchemaFactory.getSchema(schemaInputStream);
+    } catch (IOException e) {
+      throw new JsonValidationException("Failed to open schema file: " + schemaFileName, e);
+    }
+
+    final JsonNode node;
+    try {
+      node = mapper.readTree(configPath.toFile());
+    } catch (IOException e) {
+      throw new JsonValidationException("Unable to read config file: " + configPath, e);
+    }
+
+    final Set<ValidationMessage> errors = schema.validate(node);
+    if (!errors.isEmpty()) {
+      final String errorMessage =
+          errors.stream()
+              .map(ValidationMessage::getMessage)
+              .collect(Collectors.joining(System.lineSeparator()));
+      throw new JsonValidationException(errorMessage);
+    }
+  }
+
+  /**
+   * Returns a mapping from internet-accessible schema URLs to alternate local locations.
+   *
+   * <p>This allows for offline validation of schemas that refer to public URLs. The mapping is
+   * sourced from the schema/schema-map.json resource.
+   *
+   * @return A mapping from public URLs to local URLs.
+   * @throws JsonValidationException If any errors occur creating the mapping.
+   */
+  private Map<String, String> getUriMappings() throws JsonValidationException {
+    final HashMap<String, String> map = new HashMap<>();
+    try (InputStream inputStream =
+        JsonConfigValidator.class.getResourceAsStream("/schema/schema-map.json")) {
+      for (JsonNode mapping : mapper.readTree(inputStream)) {
+        map.put(mapping.get("publicURL").asText(), mapping.get("localURL").asText());
+      }
+    } catch (IOException e) {
+      throw new JsonValidationException("Failed to read schema mappings", e);
+    }
+    return map;
+  }
+}

--- a/src/main/java/com/vulcan/vmlci/orca/validator/JsonValidationException.java
+++ b/src/main/java/com/vulcan/vmlci/orca/validator/JsonValidationException.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2021 Vulcan Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.vulcan.vmlci.orca.validator;
+
+/** Exception raised during JSON validation if there are any errors. */
+public class JsonValidationException extends Exception {
+  /**
+   * Constructs a new exception with the specified detail message.
+   *
+   * @param message the detail message (which is saved for later retrieval by the {@link
+   *     #getMessage()} method).
+   * @since 1.4
+   */
+  public JsonValidationException(String message) {
+    super(message);
+  }
+
+  /**
+   * Constructs a new exception with the specified detail message and cause.
+   *
+   * <p>Note that the detail message associated with {@code cause} is <i>not</i> automatically
+   * incorporated in this exception's detail message.
+   *
+   * @param message the detail message (which is saved for later retrieval by the {@link
+   *     #getMessage()} method).
+   * @param cause the cause (which is saved for later retrieval by the {@link #getCause()} method).
+   *     (A <tt>null</tt> value is permitted, and indicates that the cause is nonexistent or
+   *     unknown.)
+   * @since 1.4
+   */
+  public JsonValidationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/resources/schema/2019-09.schema.json
+++ b/src/main/resources/schema/2019-09.schema.json
@@ -1,0 +1,62 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://json-schema.org/draft/2019-09/schema",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2019-09/vocab/core": true,
+        "https://json-schema.org/draft/2019-09/vocab/applicator": true,
+        "https://json-schema.org/draft/2019-09/vocab/validation": true,
+        "https://json-schema.org/draft/2019-09/vocab/meta-data": true,
+        "https://json-schema.org/draft/2019-09/vocab/format": false,
+        "https://json-schema.org/draft/2019-09/vocab/content": true
+    },
+    "$recursiveAnchor": true,
+    "title": "Core and Validation specifications meta-schema",
+    "allOf": [
+        {
+            "$ref": "meta/core"
+        },
+        {
+            "$ref": "meta/applicator"
+        },
+        {
+            "$ref": "meta/validation"
+        },
+        {
+            "$ref": "meta/meta-data"
+        },
+        {
+            "$ref": "meta/format"
+        },
+        {
+            "$ref": "meta/content"
+        }
+    ],
+    "type": [
+        "object",
+        "boolean"
+    ],
+    "properties": {
+        "definitions": {
+            "$comment": "While no longer an official keyword as it is replaced by $defs, this keyword is retained in the meta-schema to prevent incompatible extensions as it remains in common use.",
+            "type": "object",
+            "additionalProperties": {
+                "$recursiveRef": "#"
+            },
+            "default": {}
+        },
+        "dependencies": {
+            "$comment": "\"dependencies\" is no longer a keyword, but schema authors should avoid redefining it to facilitate a smooth transition to \"dependentSchemas\" and \"dependentRequired\"",
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    {
+                        "$recursiveRef": "#"
+                    },
+                    {
+                        "$ref": "meta/validation#/$defs/stringArray"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/src/main/resources/schema/CueConfig.schema.json
+++ b/src/main/resources/schema/CueConfig.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "Cue Configuration",
+  "description": "A configuration file containing cues and the measurements for which they will be drawn.",
+  "type": "object",
+  "properties": {
+    "format_version": {
+      "description": "The format version of the configuration file.",
+      "type": "integer"
+    },
+    "configuration": {
+      "description": "The list of cue configurations.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "cue": {
+            "description": "A cue, which is a visual marker to be drawn.",
+            "type": "string"
+          },
+          "measurements": {
+            "description": "The list of measurements for which the cue will be drawn.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/main/resources/schema/MeasurementConf.schema.json
+++ b/src/main/resources/schema/MeasurementConf.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "Measurement Configuration",
+  "description": "A configuration file containing a list of measurements and the functions + parameters used to calculate them.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "target": {
+        "description": "The measurement name.",
+        "type": "string"
+      },
+      "parameters": {
+        "description": "The parameters passed to the function used to calculate the measurement.",
+        "type": "array",
+        "items": "object"
+      },
+      "function": {
+        "description": "The function used to calculate the measurement.",
+        "type": "string"
+      }
+    }
+  }
+}

--- a/src/main/resources/schema/ReferenceConf.schema.json
+++ b/src/main/resources/schema/ReferenceConf.schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "title": "Reference Configuration",
+  "description": "A configuration file containing a list of reference markers and the functions + parameters used to calculate them.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "target": {
+        "description": "The reference marker name.",
+        "type": "string"
+      },
+      "parameters": {
+        "description": "The parameters passed to the function used to calculate the reference marker.",
+        "type": "array",
+        "items": "object"
+      },
+      "function": {
+        "description": "The function used to calculate the reference marker.",
+        "type": "string"
+      }
+    }
+  }
+}

--- a/src/main/resources/schema/schema-map.json
+++ b/src/main/resources/schema/schema-map.json
@@ -1,0 +1,6 @@
+[
+  {
+    "publicURL": "https://json-schema.org/draft/2019-09/schema",
+    "localURL": "resource:/schema/2019-09.schema.json"
+  }
+]

--- a/src/test/java/com/vulcan/vmlci/orca/helpers/ConfigurationManagerTest.java
+++ b/src/test/java/com/vulcan/vmlci/orca/helpers/ConfigurationManagerTest.java
@@ -16,7 +16,6 @@
 
 package com.vulcan.vmlci.orca.helpers;
 
-import com.vulcan.vmlci.orca.data.DataStoreTest;
 import junit.framework.TestCase;
 
 import java.nio.file.Files;
@@ -32,7 +31,8 @@ public class ConfigurationManagerTest extends TestCase {
     super.setUp();
     originalConfigPath = ConfigurationLoader.getConfigDirectory();
     final String testingConfigPath =
-        Paths.get(DataStoreTest.class.getResource("/measurement-tool-config/").toURI()).toString();
+        Paths.get(ConfigurationManagerTest.class.getResource("/measurement-tool-config/").toURI())
+            .toString();
     ConfigurationLoader.setConfigDirectory(testingConfigPath);
   }
 

--- a/src/test/java/com/vulcan/vmlci/orca/validator/JsonConfigValidatorTest.java
+++ b/src/test/java/com/vulcan/vmlci/orca/validator/JsonConfigValidatorTest.java
@@ -1,0 +1,93 @@
+/*
+ *  Copyright (c) 2021 Vulcan Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.vulcan.vmlci.orca.validator;
+
+import com.vulcan.vmlci.orca.helpers.ConfigurationFile;
+import com.vulcan.vmlci.orca.helpers.ConfigurationLoader;
+import junit.framework.TestCase;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class JsonConfigValidatorTest extends TestCase {
+  private Path originalConfigPath;
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    originalConfigPath = ConfigurationLoader.getConfigDirectory();
+    final String testingConfigPath =
+        Paths.get(JsonConfigValidatorTest.class.getResource("/measurement-tool-config/").toURI())
+            .toString();
+    ConfigurationLoader.setConfigDirectory(testingConfigPath);
+  }
+
+  public void test_validate_all_configs() throws Exception {
+    final JsonConfigValidator jsonConfigValidator = new JsonConfigValidator();
+    jsonConfigValidator.validateAllConfigs();
+    // No assertions needed. Simply not throwing an exception is sufficient for testing.
+  }
+
+  public void test_validate_invalid_config() throws Exception {
+    final JsonConfigValidator jsonConfigValidator = new JsonConfigValidator();
+    final Path configFilePath =
+        Paths.get(
+            JsonConfigValidatorTest.class
+                .getResource("/measurement-tool-config/CueConfig-InvalidFormatVersion.json")
+                .toURI());
+    try {
+      // TODO: Once this test has been updated to JUnit >= 4 then assertThrows can be used instead.
+      jsonConfigValidator.validateConfig(
+          configFilePath, ConfigurationFile.CUE_CONFIG.getSchemaFilename());
+      TestCase.fail("Expected to fail");
+    } catch (JsonValidationException e) {
+      // This is potentially brittle because error messages can change and aren't subject to a spec,
+      // but this is a fairly generic and minimal message so that isn't a large concern and it's
+      // valuable to ensure that the error is happening for the expected reason. Apologies in
+      // advance if this breaks and you have to fix it!
+      MatcherAssert.assertThat(
+          e.getMessage(),
+          CoreMatchers.containsString("format_version: string found, integer expected"));
+    }
+  }
+
+  public void test_validate_invalid_config_multiple_errors() throws Exception {
+    final JsonConfigValidator jsonConfigValidator = new JsonConfigValidator();
+    final Path configFilePath =
+        Paths.get(
+            JsonConfigValidatorTest.class
+                .getResource("/measurement-tool-config/MeasurementConf-InvalidFields.json")
+                .toURI());
+    try {
+      // TODO: Once this test has been updated to JUnit >= 4 then assertThrows can be used instead.
+      jsonConfigValidator.validateConfig(
+          configFilePath, ConfigurationFile.MEASUREMENT_CONFIG.getSchemaFilename());
+      TestCase.fail("Expected to fail");
+    } catch (JsonValidationException e) {
+      // This is potentially brittle because error messages can change and aren't subject to a spec,
+      // but this is a fairly generic and minimal message so that isn't a large concern and it's
+      // valuable to ensure that the error is happening for the expected reason. Apologies in
+      // advance if this breaks and you have to fix it!
+      MatcherAssert.assertThat(
+          e.getMessage(), CoreMatchers.containsString("parameters: string found, array expected"));
+      MatcherAssert.assertThat(
+          e.getMessage(), CoreMatchers.containsString("function: array found, string expected"));
+    }
+  }
+}

--- a/src/test/resources/measurement-tool-config/MeasurementConf-InvalidFields.json
+++ b/src/test/resources/measurement-tool-config/MeasurementConf-InvalidFields.json
@@ -1,0 +1,19 @@
+[
+  {
+    "target": "SNDF",
+    "parameters": "SNDF_x_start",
+    "function": "length"
+  },
+  {
+    "target": "BHDF",
+    "parameters": [
+      "BHDF_x_start",
+      "BHDF_y_start",
+      "BHDF_x_end",
+      "BHDF_y_end"
+    ],
+    "function": [
+      "length"
+    ]
+  }
+]


### PR DESCRIPTION
All configuration files in the user's preferences directory are validated at plugin startup time. In the future, this can also be used to pre-validate new configuration files that the user loads before they are copied to the preferences directory.

This requires a new Java library for JSON Schema validation:
https://github.com/networknt/json-schema-validator