### PR TITLE
Add capability to import and restore default configuration files.

### DIFF
--- a/src/main/java/com/vulcan/vmlci/orca/helpers/ConfigurationLoader.java
+++ b/src/main/java/com/vulcan/vmlci/orca/helpers/ConfigurationLoader.java
@@ -105,21 +105,34 @@ public final class ConfigurationLoader {
       final Path target_dir = configurationFile.getParent();
 
       createPreferenceDirectory(target_dir);
-
-      final URL resource =
-          ConfigurationLoader.class.getResource(String.format("/default_config/%s", filename));
-      if (null == resource) {
-        throw new ConfigurationFileLoadException(
-            String.format("Unknown configuration file '%s'", filename), null);
-      }
-      try {
-        Files.copy(resource.openStream(), configurationFile, StandardCopyOption.REPLACE_EXISTING);
-      } catch (final IOException e) {
-        throw new ConfigurationFileLoadException(
-            String.format("Couldn't copy config file %s", resource), e);
-      }
+      copyDefaultConfigToPath(filename, configurationFile);
     }
     return configurationFile.toString();
+  }
+
+  /**
+   * Copies the default config for the given file name to the specified path.
+   *
+   * <p>The file name must match that of a default config.
+   *
+   * @param filename The name of the default config file to copy.
+   * @param configurationFile The destination location for the default config file.
+   * @throws ConfigurationFileLoadException If there are any errors copying the config file.
+   */
+  public static void copyDefaultConfigToPath(String filename, Path configurationFile)
+      throws ConfigurationFileLoadException {
+    final URL resource =
+        ConfigurationLoader.class.getResource(String.format("/default_config/%s", filename));
+    if (null == resource) {
+      throw new ConfigurationFileLoadException(
+          String.format("Unknown configuration file '%s'", filename), null);
+    }
+    try {
+      Files.copy(resource.openStream(), configurationFile, StandardCopyOption.REPLACE_EXISTING);
+    } catch (final IOException e) {
+      throw new ConfigurationFileLoadException(
+          String.format("Couldn't copy config file %s", resource), e);
+    }
   }
 
   /**

--- a/src/main/java/com/vulcan/vmlci/orca/helpers/ConfigurationManager.java
+++ b/src/main/java/com/vulcan/vmlci/orca/helpers/ConfigurationManager.java
@@ -16,22 +16,34 @@
 
 package com.vulcan.vmlci.orca.helpers;
 
+import com.google.common.collect.Sets;
 import com.vulcan.vmlci.orca.validator.JsonConfigValidator;
 import com.vulcan.vmlci.orca.validator.JsonValidationException;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.scijava.log.Logger;
 import org.scijava.log.StderrLogService;
 
 import javax.swing.JOptionPane;
+import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 /** Helpers for managing configuration files. */
 @SuppressWarnings({"FinalClass", "UtilityClass", "UtilityClassCanBeEnum"})
@@ -40,11 +52,13 @@ public final class ConfigurationManager {
 
   private static final String FORMAT_VERSION_NAME = "format_version";
 
-  private static final String DIALOG_MESSAGE =
+  private static final String OUTDATED_CONFIG_MESSAGE =
       "Some of your existing configuration files are out of date.\n\n"
           + "You must copy new default versions of the config files in order to continue.\n\n"
           + "A backup will be made of your existing configuration files.\n\n"
           + "Would you like to proceed?";
+
+  private static final String CSV_COLUMNS_CONFIG_FILENAME = "CSV-Columns.csv";
 
   private ConfigurationManager() {}
 
@@ -75,6 +89,8 @@ public final class ConfigurationManager {
    *     replace the previous outdated configuration files.
    */
   public static boolean checkFormatVersions() {
+    final Logger logger = new StderrLogService();
+
     final Set<ConfigurationFile> outdatedConfigs;
     try {
       outdatedConfigs = getOutdatedConfigFiles();
@@ -87,7 +103,7 @@ public final class ConfigurationManager {
       final int result =
           JOptionPane.showConfirmDialog(
               null,
-              DIALOG_MESSAGE,
+              OUTDATED_CONFIG_MESSAGE,
               "Config Files Outdated",
               JOptionPane.YES_NO_OPTION,
               JOptionPane.QUESTION_MESSAGE);
@@ -193,5 +209,127 @@ public final class ConfigurationManager {
     final Path backupConfigurationFile =
         ConfigurationLoader.getAbsoluteConfigurationPath(backupFilename);
     Files.move(configurationFile, backupConfigurationFile, StandardCopyOption.REPLACE_EXISTING);
+  }
+
+  /**
+   * Copies default config files to the user's preferences directory.
+   *
+   * <p>This is used as a restore option.
+   *
+   * @throws ConfigurationFileLoadException If there are any errors copying any config files.
+   */
+  public static void copyDefaultConfigsToPreferencesDirectory()
+      throws ConfigurationFileLoadException, IOException {
+    for (ConfigurationFile configFile : ConfigurationFile.values()) {
+      final Path fullConfigPath =
+          ConfigurationLoader.getAbsoluteConfigurationPath(configFile.getFilename());
+      backupConfig(configFile.getFilename());
+      ConfigurationLoader.copyDefaultConfigToPath(configFile.getFilename(), fullConfigPath);
+    }
+
+    // The CSV columns configuration should also be restored from its default. This is somewhat of
+    // an outlier because it's not (yet) in JSON format and doesn't have an entry in the
+    // ConfigurationFile enumeration.
+    backupConfig(CSV_COLUMNS_CONFIG_FILENAME);
+    ConfigurationLoader.copyDefaultConfigToPath(
+        CSV_COLUMNS_CONFIG_FILENAME,
+        ConfigurationLoader.getAbsoluteConfigurationPath(CSV_COLUMNS_CONFIG_FILENAME));
+  }
+
+  /**
+   * Copies config files from the given {@link File} resource to the user's preferences directory.
+   *
+   * <p>The provided file may represent either a directory or a Zip file.
+   *
+   * @param input The input from which to copy configuration files.
+   * @throws IOException If any I/O errors occur.
+   * @throws JsonValidationException If any of the configuration files are invalid.
+   */
+  public static void copyNewConfigsToPreferencesDirectory(File input)
+      throws IOException, JsonValidationException {
+    final JsonConfigValidator jsonConfigValidator = new JsonConfigValidator();
+
+    if (input.isDirectory()) {
+      final Map<String, File> fileNameToFile =
+          Arrays.stream(input.listFiles())
+              .collect(Collectors.toMap(File::getName, Function.identity()));
+      checkForMissingConfigFiles(fileNameToFile.keySet());
+      for (ConfigurationFile configFile : ConfigurationFile.values()) {
+        jsonConfigValidator.validateConfig(
+            fileNameToFile.get(configFile.getFilename()).toPath(), configFile.getSchemaFilename());
+      }
+      for (ConfigurationFile configFile : ConfigurationFile.values()) {
+        backupConfig(configFile.getFilename());
+        copyToPreferencesDirectory(fileNameToFile.get(configFile.getFilename()));
+      }
+    } else if (Utilities.isZipFile(input)) {
+      try (final ZipFile zipFile = new ZipFile(input)) {
+        final Enumeration<? extends ZipEntry> zipEntries = zipFile.entries();
+        final Map<String, ZipEntry> fileNameToZipEntry = new HashMap<>();
+        while (zipEntries.hasMoreElements()) {
+          final ZipEntry zipEntry = zipEntries.nextElement();
+          fileNameToZipEntry.put(Paths.get(zipEntry.getName()).getFileName().toString(), zipEntry);
+        }
+        checkForMissingConfigFiles(fileNameToZipEntry.keySet());
+        for (ConfigurationFile configFile : ConfigurationFile.values()) {
+          jsonConfigValidator.validateConfig(
+              zipFile.getInputStream(fileNameToZipEntry.get(configFile.getFilename())),
+              configFile.getSchemaFilename());
+        }
+        for (ConfigurationFile configFile : ConfigurationFile.values()) {
+          backupConfig(configFile.getFilename());
+          copyToPreferencesDirectory(
+              zipFile.getInputStream(fileNameToZipEntry.get(configFile.getFilename())),
+              configFile.getFilename());
+        }
+      }
+    } else {
+      throw new IllegalArgumentException(
+          "Invalid config input location: " + input.getAbsolutePath());
+    }
+  }
+
+  /**
+   * Checks that all of the required config files are present in a given set of file names.
+   *
+   * @param existingFiles A set of file names. * The file names must be the last part of the path,
+   *     e.g. for "/path/to/file.txt", the set should contain "file.txt".
+   */
+  private static void checkForMissingConfigFiles(Set<String> existingFiles) {
+    final Set<String> missingConfigs =
+        Sets.difference(
+            Arrays.stream(ConfigurationFile.values())
+                .map(ConfigurationFile::getFilename)
+                .collect(Collectors.toSet()),
+            existingFiles);
+    if (!missingConfigs.isEmpty()) {
+      throw new IllegalArgumentException(
+          "Missing required configuration file(s): " + missingConfigs);
+    }
+  }
+
+  /**
+   * Copies the given file to the user's preferences directory.
+   *
+   * @param file The file to copy.
+   * @throws IOException If any I/O errors occur.
+   */
+  private static void copyToPreferencesDirectory(File file) throws IOException {
+    final Path configurationFile = ConfigurationLoader.getAbsoluteConfigurationPath(file.getName());
+    Files.copy(file.toPath(), configurationFile, StandardCopyOption.REPLACE_EXISTING);
+  }
+
+  /**
+   * Copies the contents of the given input stream to the user's preferences directory.
+   *
+   * @param inputStream The input stream from which to copy.
+   * @param fileName The name of the file, specifically the last part of the path, to write to in
+   *     the preferences directory.
+   * @throws IOException If any I/O errors occur.
+   */
+  private static void copyToPreferencesDirectory(InputStream inputStream, String fileName)
+      throws IOException {
+    final Path configurationFile = ConfigurationLoader.getAbsoluteConfigurationPath(fileName);
+    FileUtils.copyInputStreamToFile(inputStream, configurationFile.toFile());
   }
 }

--- a/src/main/java/com/vulcan/vmlci/orca/helpers/Utilities.java
+++ b/src/main/java/com/vulcan/vmlci/orca/helpers/Utilities.java
@@ -18,12 +18,15 @@ package com.vulcan.vmlci.orca.helpers;
 
 import com.opencsv.CSVReader;
 
+import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.zip.ZipException;
+import java.util.zip.ZipFile;
 
 /** Helper functions. */
 public enum Utilities {
@@ -68,5 +71,21 @@ public enum Utilities {
       result.add(record);
     }
     return result;
+  }
+
+  /**
+   * Returns whether the given {@link File} object represents a Zip archive.
+   *
+   * @param file The file to check.
+   * @return Whether the file is a Zip archive.
+   * @throws IOException If any I/O errors occur.
+   */
+  public static boolean isZipFile(File file) throws IOException {
+    try {
+      new ZipFile(file);
+      return true;
+    } catch (ZipException e) {
+      return false;
+    }
   }
 }

--- a/src/main/java/com/vulcan/vmlci/orca/ui/Branding.java
+++ b/src/main/java/com/vulcan/vmlci/orca/ui/Branding.java
@@ -19,20 +19,18 @@ package com.vulcan.vmlci.orca.ui;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
-import javax.swing.JComponent;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JMenuItem;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
-import java.awt.Component;
 import java.awt.Frame;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 
 /**
- * The <code>Branding</code> class is part of the UI that identifies the plug and manages the about
- * an help menus.
+ * The <code>Branding</code> class is part of the UI that identifies the plugin and manages the
+ * hamburger menus.
  */
 public class Branding extends JPanel {
 
@@ -87,7 +85,16 @@ public class Branding extends JPanel {
     menu.add(menuItem);
     menuItem = new JMenuItem("User Guide");
     menu.add(menuItem);
-    menuItem.addActionListener(e->new HelpLauncher((JFrame) getTopLevelAncestor()));
+    menuItem.addActionListener(e -> new HelpLauncher((JFrame) getTopLevelAncestor()));
+    menu.addSeparator();
+    menuItem = new JMenuItem("Import Configuration");
+    menu.add(menuItem);
+    menuItem.addActionListener(
+        e -> new ConfigurationImportLauncher((JFrame) getTopLevelAncestor()));
+    menuItem = new JMenuItem("Restore Default Configuration");
+    menu.add(menuItem);
+    menuItem.addActionListener(
+        e -> new ConfigurationRestoreLauncher((JFrame) getTopLevelAncestor()));
     return menu;
   }
 }

--- a/src/main/java/com/vulcan/vmlci/orca/ui/ConfigurationImportLauncher.java
+++ b/src/main/java/com/vulcan/vmlci/orca/ui/ConfigurationImportLauncher.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2021 Vulcan Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.vulcan.vmlci.orca.ui;
+
+import com.vulcan.vmlci.orca.helpers.ConfigurationManager;
+import com.vulcan.vmlci.orca.validator.JsonValidationException;
+import ij.gui.MessageDialog;
+import org.scijava.log.Logger;
+import org.scijava.log.StderrLogService;
+
+import javax.swing.JFileChooser;
+import javax.swing.JFrame;
+import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
+
+/** Launches and executes the control flow for importing configuration files. */
+public class ConfigurationImportLauncher {
+  private final JFileChooser fileChooser;
+  private final Logger logger = new StderrLogService();
+
+  public ConfigurationImportLauncher(JFrame owner) {
+    fileChooser = new JFileChooser();
+    final int result = openDialog(owner);
+    final Optional<File> file = getSelectedFile(result);
+    if (!file.isPresent()) {
+      return;
+    }
+
+    try {
+      ConfigurationManager.copyNewConfigsToPreferencesDirectory(file.get());
+    } catch (IOException | JsonValidationException e) {
+      logger.error("Problem encountered copying new configuration files", e);
+      return;
+    }
+
+    final MessageDialog doneDialog =
+        new MessageDialog(
+            owner,
+            "Please restart AMPT",
+            "New configs successfully imported.\nAMPT must be restarted for the new configuration to take effect.");
+    doneDialog.escapePressed();
+  }
+
+  private int openDialog(JFrame owner) {
+    fileChooser.setFileSelectionMode(JFileChooser.FILES_AND_DIRECTORIES);
+    return fileChooser.showOpenDialog(owner);
+  }
+
+  private Optional<File> getSelectedFile(int result) {
+    if (JFileChooser.APPROVE_OPTION == result) {
+      return Optional.of(fileChooser.getSelectedFile());
+    }
+    return Optional.empty();
+  }
+}

--- a/src/main/java/com/vulcan/vmlci/orca/ui/ConfigurationRestoreLauncher.java
+++ b/src/main/java/com/vulcan/vmlci/orca/ui/ConfigurationRestoreLauncher.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2021 Vulcan Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.vulcan.vmlci.orca.ui;
+
+import com.vulcan.vmlci.orca.helpers.ConfigurationFileLoadException;
+import com.vulcan.vmlci.orca.helpers.ConfigurationManager;
+import ij.gui.MessageDialog;
+import org.scijava.log.Logger;
+import org.scijava.log.StderrLogService;
+
+import javax.swing.JFrame;
+import javax.swing.JOptionPane;
+import java.io.IOException;
+
+/** Launches and executes the control flow for restoring default configuration files. */
+public class ConfigurationRestoreLauncher {
+  private static final String CONFIRM_OVERWRITE_MESSAGE =
+      "This will overwrite your existing configurations with the defaults\n\n"
+          + "Do you want to proceed?";
+  private final Logger logger = new StderrLogService();
+
+  public ConfigurationRestoreLauncher(JFrame owner) {
+    final int result =
+        JOptionPane.showConfirmDialog(
+            owner,
+            ConfigurationRestoreLauncher.CONFIRM_OVERWRITE_MESSAGE,
+            "Restore Default Configuration",
+            JOptionPane.YES_NO_OPTION,
+            JOptionPane.QUESTION_MESSAGE);
+    switch (result) {
+      case JOptionPane.YES_OPTION:
+        try {
+          ConfigurationManager.copyDefaultConfigsToPreferencesDirectory();
+        } catch (ConfigurationFileLoadException | IOException e) {
+          logger.error(e);
+        }
+        break;
+      case JOptionPane.NO_OPTION:
+      default:
+        return;
+    }
+
+    final MessageDialog doneDialog =
+        new MessageDialog(
+            owner,
+            "Please restart AMPT",
+            "Default configs successfully restored.\nAMPT must be restarted for the new configuration to take effect.");
+    doneDialog.escapePressed();
+  }
+}

--- a/src/test/java/com/vulcan/vmlci/orca/validator/JsonConfigValidatorTest.java
+++ b/src/test/java/com/vulcan/vmlci/orca/validator/JsonConfigValidatorTest.java
@@ -22,6 +22,8 @@ import junit.framework.TestCase;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 
+import java.io.FileInputStream;
+import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -55,6 +57,29 @@ public class JsonConfigValidatorTest extends TestCase {
       // TODO: Once this test has been updated to JUnit >= 4 then assertThrows can be used instead.
       jsonConfigValidator.validateConfig(
           configFilePath, ConfigurationFile.CUE_CONFIG.getSchemaFilename());
+      TestCase.fail("Expected to fail");
+    } catch (JsonValidationException e) {
+      // This is potentially brittle because error messages can change and aren't subject to a spec,
+      // but this is a fairly generic and minimal message so that isn't a large concern and it's
+      // valuable to ensure that the error is happening for the expected reason. Apologies in
+      // advance if this breaks and you have to fix it!
+      MatcherAssert.assertThat(
+          e.getMessage(),
+          CoreMatchers.containsString("format_version: string found, integer expected"));
+    }
+  }
+
+  public void test_validate_invalid_config_input_stream() throws Exception {
+    final JsonConfigValidator jsonConfigValidator = new JsonConfigValidator();
+    final Path configFilePath =
+        Paths.get(
+            JsonConfigValidatorTest.class
+                .getResource("/measurement-tool-config/CueConfig-InvalidFormatVersion.json")
+                .toURI());
+    try (InputStream configInputStream = new FileInputStream(configFilePath.toFile())) {
+      // TODO: Once this test has been updated to JUnit >= 4 then assertThrows can be used instead.
+      jsonConfigValidator.validateConfig(
+          configInputStream, ConfigurationFile.CUE_CONFIG.getSchemaFilename());
       TestCase.fail("Expected to fail");
     } catch (JsonValidationException e) {
       // This is potentially brittle because error messages can change and aren't subject to a spec,


### PR DESCRIPTION
This change adds two new options to the hamburger menu:
* Import Configuration
* Restore Default Configuration

When importing, config files may be provided either from a directory or a Zip archive.

Either importing new config files or restoring default config files requires an AMPT restart.