### PR TITLE
Add a test to ensure that the default configs are valid.

### DIFF
--- a/src/main/java/com/vulcan/vmlci/orca/helpers/ConfigurationLoader.java
+++ b/src/main/java/com/vulcan/vmlci/orca/helpers/ConfigurationLoader.java
@@ -107,7 +107,8 @@ public final class ConfigurationLoader {
       createPreferenceDirectory(target_dir);
 
       final URL resource =
-          ConfigurationLoader.class.getResource(String.format("/default_config/%s", filename));
+          ConfigurationLoader.class.getResource(
+              Paths.get(getDefaultConfigDirectory(), filename).toString());
       if (null == resource) {
         throw new ConfigurationFileLoadException(
             String.format("Unknown configuration file '%s'", filename), null);
@@ -120,6 +121,18 @@ public final class ConfigurationLoader {
       }
     }
     return configurationFile.toString();
+  }
+
+  /**
+   * Returns the path to the default config directory.
+   *
+   * <p>In other words, this is the resources directory storing the default configs that are
+   * packaged with the executable. Note that these files are read-only.
+   *
+   * @return A path to the directory that contains the default configuration files.
+   */
+  public static String getDefaultConfigDirectory() {
+    return "/default_config";
   }
 
   /**

--- a/src/test/java/com/vulcan/vmlci/orca/validator/JsonConfigValidatorTest.java
+++ b/src/test/java/com/vulcan/vmlci/orca/validator/JsonConfigValidatorTest.java
@@ -38,7 +38,18 @@ public class JsonConfigValidatorTest extends TestCase {
     ConfigurationLoader.setConfigDirectory(testingConfigPath);
   }
 
-  public void test_validate_all_configs() throws Exception {
+  public void test_validate_all_default_configs() throws Exception {
+    final JsonConfigValidator jsonConfigValidator = new JsonConfigValidator();
+    ConfigurationLoader.setConfigDirectory(
+        Paths.get(
+            ConfigurationLoader.class
+                .getResource(ConfigurationLoader.getDefaultConfigDirectory())
+                .toURI()));
+    jsonConfigValidator.validateAllConfigs();
+    // No assertions needed. Simply not throwing an exception is sufficient for testing.
+  }
+
+  public void test_validate_all_test_configs() throws Exception {
     final JsonConfigValidator jsonConfigValidator = new JsonConfigValidator();
     jsonConfigValidator.validateAllConfigs();
     // No assertions needed. Simply not throwing an exception is sufficient for testing.


### PR DESCRIPTION
This allows us to ensure that we are shipping valid configs with any new release of the AMPT plugin.

Refactor the code a bit so that it's easy to read the location of the default config directory.

Fixes #41