### PR TITLE
Copy attribution.xml into the jar file at build time.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,30 @@
                     <outputFile>${project.build.directory}/attribution.xml</outputFile>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${basedir}/target</directory>
+                                    <includes>
+                                        <include>attribution.xml</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Reference: https://stackoverflow.com/questions/586202/best-practices-for-copying-files-with-maven

Fixes #61.