### PR TITLE
Add a workflow that pushes to the ImageJ update site and deploys documentation for new releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: 'Release to ImageJ update site'
+on:
+  release:
+    types: [published]
+  workflow_dispatch: # Allow manual triggering.
+jobs:
+  build_release:
+    runs-on: 'ubuntu-latest'
+    env:
+      IJ_DOWNLOAD_URL: 'https://downloads.imagej.net/fiji/latest/fiji-linux64.tar.gz'
+      WIKI_USER: 'ampt-dev'
+      UPDATE_PASS: '${{ secrets.IMAGEJ_UPDATE_SITE_PASS }}'
+      UPDATE_SITE: 'AMPT'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@v2'
+      - name: 'Build with Maven'
+        run: 'mvn -B package'
+      - name: 'Install ImageJ/Fiji'
+        run: |
+          curl --silent ${IJ_DOWNLOAD_URL} | tar --extract --gzip
+          ./Fiji.app/ImageJ-linux64 --headless --update edit-update-site ${UPDATE_SITE} https://sites.imagej.net/${UPDATE_SITE}/ "webdav:${WIKI_USER}:${UPDATE_PASS}" .
+      - name: 'Install in ImageJ/Fiji (with Maven)'
+        run: |
+          mvn -B install -Dscijava.app.directory=./Fiji.app -Ddelete.other.versions=true -Dscijava.ignoreDependencies=true
+      - name: 'Release to ImageJ update site'
+        run: |
+          ./Fiji.app/ImageJ-linux64 --headless --update upload-complete-site --force ${UPDATE_SITE}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: 'Release to ImageJ update site'
+name: 'Release to ImageJ update site and deploy GitHub documentation'
 on:
   release:
     types: [published]
@@ -26,3 +26,6 @@ jobs:
       - name: 'Release to ImageJ update site'
         run: |
           ./Fiji.app/ImageJ-linux64 --headless --update upload-complete-site --force ${UPDATE_SITE}
+      - name: 'Deploy GitHub documentation'
+        working-directory: './doc_source'
+        run: 'make gh-deploy'


### PR DESCRIPTION
- This is based on the [ImageJ automatic uploads](https://imagej.net/update-sites/automatic-uploads) documentation and sample workflow provided there.
- This also deploys the documentation to GitHub.
- Allows for manual triggering of the workflow for testing / one-off cases.

Fixes #56 