### PR TITLE
Always use slash (/) for resource path separator.

### DIFF
--- a/src/main/java/org/allenai/allenmli/orca/helpers/ConfigurationLoader.java
+++ b/src/main/java/org/allenai/allenmli/orca/helpers/ConfigurationLoader.java
@@ -122,7 +122,8 @@ public final class ConfigurationLoader {
   public static void copyDefaultConfigToPath(String filename, Path configurationFile)
       throws ConfigurationFileLoadException {
     final URL resource =
-        ConfigurationLoader.class.getResource(Paths.get(getDefaultConfigDirectory(), filename).toString());
+        ConfigurationLoader.class.getResource(
+            String.format("%s/%s", getDefaultConfigDirectory(), filename));
     if (null == resource) {
       throw new ConfigurationFileLoadException(
           String.format("Unknown configuration file '%s'", filename), null);


### PR DESCRIPTION
This fixes a Windows-specific bug in which the system file separator (`\`) was being used. According to the Java documentation, the path separator should always be a forward slash.

Reference:
https://docs.oracle.com/javase/8/docs/technotes/guides/lang/resources.html

Fixes #105