### PR TITLE
Simplify Java setup in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,9 @@ jobs:
       - uses: 'actions/checkout@v2'
       - uses: 'actions/setup-java@v2'
         with:
-          java-version: 8
+          distribution: 'temurin'
+          java-version: '8'
+          cache: 'maven'
       - name: 'Build with Maven'
         run: 'mvn -B package'
       - name: 'Install ImageJ/Fiji'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,16 +12,10 @@ jobs:
       UPDATE_PASS: '${{ secrets.IMAGEJ_UPDATE_SITE_PASS }}'
       UPDATE_SITE: 'AMPT'
     steps:
-      - name: 'Checkout'
-        uses: 'actions/checkout@v2'
-      - name: 'Install packages'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y openjdk-8-jdk virtualenv
-          sudo apt-get clean
-      - name: 'Set JAVA_HOME'
-        run: |
-          echo "JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/" >> $GITHUB_ENV
+      - uses: 'actions/checkout@v2'
+      - uses: 'actions/setup-java@v2'
+        with:
+          java-version: 8
       - name: 'Build with Maven'
         run: 'mvn -B package'
       - name: 'Install ImageJ/Fiji'


### PR DESCRIPTION
This simplifies the release workflow by:

- Using the `setup-java` action to set up Java 8 instead of doing a manual JDK installation.
- Remove the now unnecessary manual installation of `virtualenv` (once #112 is merged).